### PR TITLE
Set more specific version constraint for slugify

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"propel/propel1": "~1.6",
 		"aws/aws-sdk-php": "~2.4",
-		"cocur/slugify": "@stable"
+		"cocur/slugify": "~1.4"
 	},
 	"autoload": {
 		"classmap": ["src/"]


### PR DESCRIPTION
We will be releasing a 2.0 version of Slugify in the next couple of months and since it might break compatibility I suggest setting a more specific version constraint.
